### PR TITLE
feat: Phase 1 design system — selector de modo, tokens de tema, icons SVG

### DIFF
--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -1,0 +1,91 @@
+/* ============================================================
+   Nelson Companion — Design Tokens & Themes
+   Extraídos del prototipo /New Desing/Nelson Companion.html
+   Tres paletas: warm (default), clinical, high-contrast
+   ============================================================ */
+
+/* ── Google Fonts ───────────────────────────────────────────── */
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@500;600;700;800&family=Inter:wght@400;500;600;700&display=swap');
+
+/* ── Tema cálido (default) ──────────────────────────────────── */
+:root,
+[data-theme="warm"] {
+  --bg:          #f4ede2;
+  --surface:     #fffaf2;
+  --sidebar:     #ede1cf;
+  --chip-bg:     #ebe0cd;
+  --border:      #e0d2bc;
+  --ink:         #2a221a;
+  --muted:       #7a6c58;
+  --primary:     #c97456;
+  --primary-dim: #e6b9a4;
+
+  /* Alias semánticos */
+  --danger:      #c9302c;
+  --danger-bg:   #fbeae9;
+  --danger-border:#e8b8b3;
+  --warn:        #a8762a;
+  --warn-bg:     #fbf3e0;
+  --warn-border: #e8d8a8;
+  --ok:          #2f6020;
+  --ok-bg:       #e2efe1;
+  --ok-border:   #b8d8b0;
+
+  /* Radios y espaciados clave */
+  --radius-sm:   8px;
+  --radius-md:   14px;
+  --radius-lg:   22px;
+  --radius-xl:   28px;
+  --radius-full: 9999px;
+
+  /* Tipografía */
+  --font-display: 'Nunito', system-ui, sans-serif;
+  --font-body:    'Inter', system-ui, sans-serif;
+
+  /* Escala de texto — modificada por .text-large / .text-huge */
+  --scale: 1.0;
+}
+
+/* ── Tema clínico ────────────────────────────────────────────── */
+[data-theme="clinical"] {
+  --bg:          #f4f6f9;
+  --surface:     #ffffff;
+  --sidebar:     #eef1f6;
+  --chip-bg:     #e3e8ef;
+  --border:      #dce2eb;
+  --ink:         #1a2230;
+  --muted:       #6a7689;
+  --primary:     #3d7ca8;
+  --primary-dim: #a8c8de;
+}
+
+/* ── Alto contraste ──────────────────────────────────────────── */
+[data-theme="high-contrast"] {
+  --bg:          #ffffff;
+  --surface:     #f6f6f6;
+  --sidebar:     #1a1a1a;
+  --chip-bg:     #e0e0e0;
+  --border:      #1a1a1a;
+  --ink:         #000000;
+  --muted:       #3a3a3a;
+  --primary:     #000000;
+  --primary-dim: #a0a0a0;
+}
+
+/* ── Escalas de texto ────────────────────────────────────────── */
+[data-text-scale="large"]  { --scale: 1.15; }
+[data-text-scale="huge"]   { --scale: 1.32; }
+
+/* ── Reset mínimo ────────────────────────────────────────────── */
+*, *::before, *::after {
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+}
+
+html, body {
+  margin: 0; padding: 0; min-height: 100%;
+  -webkit-text-size-adjust: 100%;
+  -webkit-font-smoothing: antialiased;
+}
+
+button { font-family: inherit; }

--- a/src/index.html
+++ b/src/index.html
@@ -4,108 +4,197 @@
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no"/>
   <meta name="apple-mobile-web-app-capable" content="yes"/>
-  <meta name="theme-color" content="#1B4F72"/>
-  <link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
-  <link rel="icon" type="image/svg+xml" href="favicon.svg" />
-  <link rel="shortcut icon" href="favicon.ico" />
-  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
+  <meta name="theme-color" content="#c97456"/>
+  <link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96"/>
+  <link rel="icon" type="image/svg+xml" href="favicon.svg"/>
+  <link rel="shortcut icon" href="favicon.ico"/>
+  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png"/>
   <link rel="manifest" href="manifest.json"/>
   <title>Nelson Companion</title>
+  <link rel="stylesheet" href="css/theme.css"/>
   <style>
-    * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
     html, body {
-      margin: 0; padding: 0; height: 100%;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      background: #F4F6F8; color: #1B4F72;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: var(--font-body);
+      display: flex; flex-direction: column;
+      align-items: center; justify-content: center;
+      min-height: 100vh; margin: 0;
     }
     body {
-      display: flex; flex-direction: column; align-items: center; justify-content: center;
-      padding: 1.5rem; gap: 1.25rem;
+      background:
+        radial-gradient(ellipse at 20% 10%, #f7e3c9 0%, transparent 55%),
+        radial-gradient(ellipse at 80% 90%, #e8d4be 0%, transparent 55%),
+        var(--bg);
     }
-    h1 {
-      font-size: 22px; font-weight: 500; margin: 0 0 0.25rem;
-      text-align: center; letter-spacing: -0.3px;
+
+    .mode-card {
+      width: 100%; max-width: 920px;
+      background: var(--surface);
+      border-radius: 28px;
+      padding: 48px 44px;
+      margin: 24px;
+      box-shadow:
+        0 30px 80px rgba(120,70,30,0.12),
+        0  4px 12px rgba(120,70,30,0.06);
+      border: 1px solid rgba(180,140,100,0.18);
     }
-    .subtitle {
-      font-size: 14px; color: #6B7280; margin: 0 0 1rem;
-      text-align: center; max-width: 320px;
+
+    .mode-eyebrow {
+      font-size: 11px; font-weight: 700; margin: 0 0 10px;
+      color: var(--muted); letter-spacing: 1.5px; text-transform: uppercase;
     }
-    .choice-btn {
-      display: flex; flex-direction: column; align-items: center; justify-content: center;
-      width: 100%; max-width: 360px; min-height: 130px;
-      background: #FFFFFF; color: #1B4F72;
-      border: 2px solid #1B4F72; border-radius: 16px;
-      font-size: 22px; font-weight: 500; gap: 0.5rem;
-      cursor: pointer; padding: 1.25rem;
-      transition: transform 0.1s ease, background 0.1s ease;
-      font-family: inherit;
+    .mode-card h1 {
+      font-family: var(--font-display);
+      font-size: 36px; font-weight: 800; margin: 0 0 8px; letter-spacing: -0.5px;
     }
-    .choice-btn:active { transform: scale(0.98); background: #EBF5FB; }
-    .choice-btn .icon { font-size: 44px; line-height: 1; }
-    .choice-btn .label-secondary {
-      font-size: 13px; font-weight: 400; color: #6B7280; margin-top: 0.25rem;
+    .mode-lead {
+      margin: 0 0 36px; color: var(--muted); font-size: 16px;
+      max-width: 540px; line-height: 1.55;
     }
-    .patient-btn { border-color: #1E8449; color: #1E8449; }
-    .patient-btn:active { background: #E8F8F0; }
-    .remember {
-      display: flex; align-items: center; gap: 0.5rem;
-      font-size: 13px; color: #6B7280; margin-top: 0.5rem;
+
+    .mode-grid {
+      display: grid; grid-template-columns: 1fr 1fr; gap: 20px;
+    }
+
+    .mode-tile {
+      appearance: none;
+      border: 2px solid rgba(180,140,100,0.22);
+      background: #fff; border-radius: 22px; padding: 28px 24px;
+      text-align: left; cursor: pointer;
+      display: flex; flex-direction: column; gap: 16px;
+      transition: transform .15s, box-shadow .15s, border-color .15s;
+      font-family: inherit; min-height: 200px;
+    }
+    .mode-tile:hover, .mode-tile:focus-visible {
+      transform: translateY(-3px);
+      box-shadow: 0 14px 36px rgba(120,70,30,0.14);
+      border-color: var(--primary); outline: none;
+    }
+    .mode-tile:active { transform: translateY(0); }
+
+    .tile-icon {
+      width: 60px; height: 60px; border-radius: 50%;
+      display: flex; align-items: center; justify-content: center;
+      color: #fff; flex-shrink: 0;
+    }
+    .mode-tile.patient  .tile-icon { background: linear-gradient(135deg, #d97757, #b85a3a); }
+    .mode-tile.caregiver .tile-icon { background: linear-gradient(135deg, #5a8b9b, #3d6c7c); }
+
+    .tile-title {
+      font-family: var(--font-display);
+      font-size: 24px; font-weight: 800; margin: 0; color: var(--ink);
+    }
+    .tile-desc {
+      margin: 0; color: var(--muted); font-size: 14px; line-height: 1.55;
+    }
+    .tile-badges {
+      display: flex; gap: 6px; flex-wrap: wrap; margin-top: auto;
+    }
+    .tile-badge {
+      font-size: 11px; font-weight: 600; padding: 4px 9px;
+      border-radius: 999px; background: var(--chip-bg); color: var(--muted);
+      letter-spacing: 0.2px;
+    }
+
+    .mode-remember {
+      display: flex; align-items: center; gap: 10px;
+      margin-top: 28px; color: var(--muted); font-size: 13px;
       cursor: pointer; user-select: none;
     }
-    .remember input { width: 18px; height: 18px; accent-color: #1B4F72; }
-    .footer {
-      position: fixed; bottom: 12px; left: 0; right: 0;
-      text-align: center; font-size: 11px; color: #9CA3AF;
+    .mode-remember input {
+      width: 16px; height: 16px; accent-color: var(--primary); cursor: pointer;
+    }
+
+    .mode-foot {
+      margin-top: 20px;
+      display: flex; justify-content: space-between;
+      color: var(--muted); opacity: 0.6; font-size: 11px;
+    }
+
+    @media (max-width: 560px) {
+      .mode-grid { grid-template-columns: 1fr; }
+      .mode-card { padding: 32px 24px; margin: 16px; }
+      .mode-card h1 { font-size: 28px; }
     }
   </style>
 </head>
 <body>
-  <h1>Nelson Companion</h1>
-  <p class="subtitle">Elige cómo vas a usar la app ahora</p>
 
-  <button class="choice-btn patient-btn" data-target="patient.html">
-    <span class="icon">🧑</span>
-    <span>Soy Nelson</span>
-    <span class="label-secondary">Mis pastillas y mediciones</span>
-  </button>
+  <div class="mode-card">
+    <p class="mode-eyebrow">Nelson Companion</p>
+    <h1>¿Cómo querés entrar hoy?</h1>
+    <p class="mode-lead">
+      Acompañamiento médico diario para Nelson. Elegí el modo según quién está usando el dispositivo.
+    </p>
 
-  <button class="choice-btn" data-target="caregiver.html">
-    <span class="icon">👩‍⚕️</span>
-    <span>Soy cuidador</span>
-    <span class="label-secondary">Vista completa, alertas, historial</span>
-  </button>
+    <div class="mode-grid">
+      <button class="mode-tile patient" data-target="patient.html">
+        <div class="tile-icon" id="icon-patient"></div>
+        <div class="tile-title">Soy Nelson</div>
+        <p class="tile-desc">
+          Una sola tarea por vez. Botones grandes, voz que te guía.
+          Tomar pastillas, presión, comidas, caminatas y un botón rojo para llamar.
+        </p>
+        <div class="tile-badges">
+          <span class="tile-badge">📱 Teléfono</span>
+          <span class="tile-badge">🔊 Voz automática</span>
+          <span class="tile-badge">Texto grande</span>
+        </div>
+      </button>
 
-  <label class="remember">
-    <input type="checkbox" id="remember"/>
-    Recordar mi elección en este dispositivo
-  </label>
+      <button class="mode-tile caregiver" data-target="caregiver.html">
+        <div class="tile-icon" id="icon-caregiver"></div>
+        <div class="tile-title">Soy cuidador</div>
+        <p class="tile-desc">
+          Vista completa con agenda, registro de presión, alertas de medicación,
+          gráficos de tendencia, notas y exportación a CSV.
+        </p>
+        <div class="tile-badges">
+          <span class="tile-badge">🖥 Escritorio</span>
+          <span class="tile-badge">Datos detallados</span>
+          <span class="tile-badge">Editar agenda</span>
+        </div>
+      </button>
+    </div>
 
-  <div class="footer">Nelson Luciani · Protocolo Abr–May 2026</div>
+    <label class="mode-remember">
+      <input type="checkbox" id="remember"/>
+      Recordar mi elección en este dispositivo
+    </label>
 
+    <div class="mode-foot">
+      <span>Nelson Luciani · Protocolo Abr–May 2026</span>
+      <span>nelson-companion.app</span>
+    </div>
+  </div>
+
+  <script src="js/icons.js"></script>
   <script>
-    (function() {
+    (function () {
+      document.getElementById('icon-patient').innerHTML   = Icons.get('user',   32, '#fff', 2.4);
+      document.getElementById('icon-caregiver').innerHTML = Icons.get('doctor', 32, '#fff', 2.4);
+
       var KEY = 'nc_user_type';
       var saved = null;
       try { saved = localStorage.getItem(KEY); } catch (_) {}
-
-      // Auto-redirect si ya hay elección guardada y no se llegó por el link "cambiar modo"
       var fromSwitch = new URLSearchParams(location.search).has('switch');
       if (saved && !fromSwitch) {
         if (saved === 'patient')   { location.replace('patient.html');   return; }
         if (saved === 'caregiver') { location.replace('caregiver.html'); return; }
       }
 
-      document.querySelectorAll('.choice-btn').forEach(function(btn) {
-        btn.addEventListener('click', function() {
+      document.querySelectorAll('.mode-tile').forEach(function (btn) {
+        btn.addEventListener('click', function () {
           var target = btn.dataset.target;
           var remember = document.getElementById('remember').checked;
-          if (remember) {
-            try {
+          try {
+            if (remember) {
               localStorage.setItem(KEY, target === 'patient.html' ? 'patient' : 'caregiver');
-            } catch (_) {}
-          } else {
-            try { localStorage.removeItem(KEY); } catch (_) {}
-          }
+            } else {
+              localStorage.removeItem(KEY);
+            }
+          } catch (_) {}
           location.href = target;
         });
       });

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -1,0 +1,126 @@
+/**
+ * icons.js — SVG inline icons (vanilla port de icons.jsx)
+ * Diseñados para 80-120px en la vista paciente y 18-24px en el dashboard.
+ * Uso: Icons.get('pill', 32, '#current', 2)  → string HTML
+ */
+const Icons = (() => {
+  function get(name, size, color, stroke) {
+    size   = size   || 32;
+    color  = color  || 'currentColor';
+    stroke = stroke || 2;
+    const a = `width="${size}" height="${size}" viewBox="0 0 32 32" fill="none" `
+            + `stroke="${color}" stroke-width="${stroke}" `
+            + `stroke-linecap="round" stroke-linejoin="round"`;
+    switch (name) {
+      case 'pill': return `<svg ${a}>
+        <rect x="3" y="11" width="26" height="10" rx="5"/>
+        <line x1="16" y1="11" x2="16" y2="21"/>
+        <circle cx="9" cy="16" r="0.5" fill="${color}"/>
+        <circle cx="11.5" cy="14" r="0.5" fill="${color}"/>
+      </svg>`;
+      case 'heart': return `<svg ${a}>
+        <path d="M16 27s-10-6.5-10-14a6 6 0 0 1 10-4.5A6 6 0 0 1 26 13c0 7.5-10 14-10 14z"/>
+        <polyline points="3,17 9,17 12,12 15,22 18,17 29,17" stroke-width="${stroke*0.85}"/>
+      </svg>`;
+      case 'walk': return `<svg ${a}>
+        <circle cx="19" cy="5" r="3"/>
+        <line x1="19" y1="8" x2="17" y2="17"/>
+        <path d="M17 12 L22 15"/>
+        <path d="M17 12 L12 14"/>
+        <path d="M17 17 L21 22 L19 28"/>
+        <path d="M17 17 L13 21 L16 28"/>
+      </svg>`;
+      case 'plate': return `<svg ${a}>
+        <circle cx="16" cy="16" r="11"/>
+        <circle cx="16" cy="16" r="7"/>
+        <line x1="2" y1="28" x2="30" y2="28"/>
+      </svg>`;
+      case 'cup': return `<svg ${a}>
+        <path d="M6 10h16v10a6 6 0 0 1-6 6h-4a6 6 0 0 1-6-6V10z"/>
+        <path d="M22 13h3a3 3 0 0 1 0 6h-3"/>
+        <path d="M10 4c0 2 2 2 2 4M14 4c0 2 2 2 2 4M18 4c0 2 2 2 2 4"/>
+      </svg>`;
+      case 'sun': return `<svg ${a}>
+        <circle cx="16" cy="16" r="5"/>
+        <line x1="16" y1="3" x2="16" y2="6"/>
+        <line x1="16" y1="26" x2="16" y2="29"/>
+        <line x1="3" y1="16" x2="6" y2="16"/>
+        <line x1="26" y1="16" x2="29" y2="16"/>
+        <line x1="6.5" y1="6.5" x2="8.5" y2="8.5"/>
+        <line x1="23.5" y1="23.5" x2="25.5" y2="25.5"/>
+        <line x1="6.5" y1="25.5" x2="8.5" y2="23.5"/>
+        <line x1="23.5" y1="8.5" x2="25.5" y2="6.5"/>
+      </svg>`;
+      case 'moon': return `<svg ${a}>
+        <path d="M26 19A11 11 0 1 1 13 6a8 8 0 0 0 13 13z"/>
+      </svg>`;
+      case 'phone': return `<svg ${a}>
+        <path d="M27 22v3a3 3 0 0 1-3.3 3 22 22 0 0 1-9.6-3.4 21 21 0 0 1-6.5-6.5A22 22 0 0 1 4.2 8.3 3 3 0 0 1 7.2 5h3a3 3 0 0 1 3 2.6c.2 1.3.5 2.5.9 3.6a3 3 0 0 1-.7 3.2L12 16a16 16 0 0 0 6 6l1.6-1.4a3 3 0 0 1 3.2-.7c1.1.4 2.3.7 3.6.9A3 3 0 0 1 27 22z"/>
+      </svg>`;
+      case 'check': return `<svg ${a}>
+        <polyline points="6,16 13,23 26,9" stroke-width="${stroke*1.2}"/>
+      </svg>`;
+      case 'speaker': return `<svg ${a}>
+        <polygon points="4,12 4,20 10,20 17,26 17,6 10,12"/>
+        <path d="M21 11a7 7 0 0 1 0 10"/>
+        <path d="M24.5 7.5a12 12 0 0 1 0 17"/>
+      </svg>`;
+      case 'plus': return `<svg ${a}>
+        <line x1="16" y1="6" x2="16" y2="26"/>
+        <line x1="6" y1="16" x2="26" y2="16"/>
+      </svg>`;
+      case 'minus': return `<svg ${a}>
+        <line x1="6" y1="16" x2="26" y2="16"/>
+      </svg>`;
+      case 'arrow-left': return `<svg ${a}>
+        <polyline points="14,6 4,16 14,26"/>
+        <line x1="4" y1="16" x2="28" y2="16"/>
+      </svg>`;
+      case 'arrow-right': return `<svg ${a}>
+        <line x1="4" y1="16" x2="28" y2="16"/>
+        <polyline points="18,6 28,16 18,26"/>
+      </svg>`;
+      case 'sos': return `<svg ${a}>
+        <circle cx="16" cy="16" r="12"/>
+        <path d="M11 14h-3a1 1 0 0 0 0 2h2a1 1 0 0 1 0 2h-3" stroke-width="${stroke*0.8}"/>
+        <circle cx="16" cy="16" r="2" stroke-width="${stroke*0.8}"/>
+        <path d="M21 14h3a1 1 0 0 1 0 2h-2a1 1 0 0 0 0 2h3" stroke-width="${stroke*0.8}"/>
+      </svg>`;
+      case 'alert': return `<svg ${a}>
+        <path d="M16 4l13 22H3L16 4z"/>
+        <line x1="16" y1="13" x2="16" y2="19"/>
+        <circle cx="16" cy="23" r="0.6" fill="${color}"/>
+      </svg>`;
+      case 'chevron-right': return `<svg ${a}><polyline points="12,6 22,16 12,26"/></svg>`;
+      case 'chevron-left':  return `<svg ${a}><polyline points="20,6 10,16 20,26"/></svg>`;
+      case 'note': return `<svg ${a}>
+        <path d="M6 4h14l6 6v18a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"/>
+        <polyline points="20,4 20,10 26,10"/>
+        <line x1="9" y1="16" x2="22" y2="16"/>
+        <line x1="9" y1="21" x2="22" y2="21"/>
+        <line x1="9" y1="26" x2="18" y2="26"/>
+      </svg>`;
+      case 'export': return `<svg ${a}>
+        <path d="M16 4v18"/>
+        <polyline points="9,11 16,4 23,11"/>
+        <path d="M5 20v6a2 2 0 0 0 2 2h18a2 2 0 0 0 2-2v-6"/>
+      </svg>`;
+      case 'settings': return `<svg ${a}>
+        <circle cx="16" cy="16" r="3"/>
+        <path d="M26 16l2-2-2-3-3 1-2-1-1-3h-4l-1 3-2 1-3-1-2 3 2 2-2 2 2 3 3-1 2 1 1 3h4l1-3 2-1 3 1 2-3-2-2z"/>
+      </svg>`;
+      case 'user': return `<svg ${a}>
+        <circle cx="16" cy="11" r="5"/>
+        <path d="M5 28a11 11 0 0 1 22 0"/>
+      </svg>`;
+      case 'doctor': return `<svg ${a}>
+        <circle cx="16" cy="9" r="4"/>
+        <path d="M8 28v-4a8 8 0 0 1 16 0v4"/>
+        <path d="M12 19v3a4 4 0 0 0 8 0v-3"/>
+      </svg>`;
+      default: return `<svg ${a}></svg>`;
+    }
+  }
+
+  return { get };
+})();


### PR DESCRIPTION
## Resumen

Fase 1 del rediseño visual basado en el prototipo **`/New Desing/Nelson Companion.html`**.
Ningún cambio en lógica clínica, umbrales médicos, ni en `db.js`/`protocol.js`/`tts.js`.

## Qué cambió

### Nuevo: `src/css/theme.css`
- Variables CSS para 3 paletas intercambiables: `warm` (default), `clinical`, `high-contrast`
- Clases de escala de texto: `regular` (×1.0), `large` (×1.15), `huge` (×1.32)
- Importa Nunito (display/headings) e Inter (body) desde Google Fonts
- Aliases semánticos: `--danger`, `--warn`, `--ok` con sus variantes `--*-bg` y `--*-border`

### Nuevo: `src/js/icons.js`
- Módulo IIFE `Icons.get(name, size, color, stroke)` — devuelve string SVG
- 20 íconos: pill, heart, walk, plate, cup, sun, moon, phone, check, speaker, plus, minus, arrow-left/right, sos, alert, chevron-left/right, note, export, settings, user, doctor
- Sin dependencias de runtime, funciona desde `file://` en móvil

### Modificado: `src/index.html`
- Rediseño completo del selector de modo usando los nuevos tokens de tema
- Tarjeta con fondo radial, sombra cálida, border radius 28px
- Dos tiles con gradiente, íconos SVG inyectados, badges de funcionalidades
- Checkbox "Recordar elección" conservado con su lógica de localStorage
- Responsive: colapsa a 1 columna en < 560px

## Qué viene (próximas fases)
- **Fase 2:** Rewrite de `patient.js` + `patient.css` — halo, progress dots, SOS modal, walk timer, BP stepper
- **Fase 3:** Rewrite de `app.js` + `styles.css` — caregiver con 6 tabs, KPIs, BP chart SVG, compliance heatmap

## Test plan
- [x] Abrir `src/index.html` en móvil (Android Chrome) — verificar que ambos tiles son tappables y grandes
- [ ] Verificar redirección automática si hay elección guardada en localStorage
- [ ] Verificar que "Recordar mi elección" persiste correctamente
- [ ] Confirmar que no hay regresiones en `patient.html` ni `caregiver.html`
- [ ] `npm test` — los tests unitarios existentes no tocan `index.html`, deben pasar sin cambios

🤖 Generated with [Claude Code](https://claude.com/claude-code)