### PR TITLE
feat: Infisical + ElevenLabs audios + CI pipeline + GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,10 +27,11 @@ jobs:
       - name: Inject secrets from Infisical
         uses: Infisical/secrets-action@v1.0.7
         with:
+          method: universal-auth
           client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
           client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          project-slug: "nelson-companion-ea-mt"
           env-slug: "production"
-          project-id: "2a182da9-5baf-4b8a-81b0-f8bd009a6a97"
           secret-path: "/"
           export-type: env
 

--- a/.github/workflows/send-push.yml
+++ b/.github/workflows/send-push.yml
@@ -27,10 +27,11 @@ jobs:
       - name: Inject secrets from Infisical
         uses: Infisical/secrets-action@v1.0.7
         with:
+          method: universal-auth
           client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
           client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          project-slug: "nelson-companion-ea-mt"
           env-slug: "production"
-          project-id: "2a182da9-5baf-4b8a-81b0-f8bd009a6a97"
           secret-path: "/"
           export-type: env
 


### PR DESCRIPTION
## Summary

- **Infisical**: integración completa de secrets management en `deploy.yml` y `send-push.yml` — `method: universal-auth`, `project-slug: nelson-companion-ea-mt`, elimina input inválido `project-id`
- **ElevenLabs**: generador de audios pregrabados (`scripts/generate-audio.js`) con voz Valentina, deduplicación por texto — 77 archivos `.mp3` en `src/assets/audio/`
- **CI pipeline**: nuevo `ci.yml` — corre los 78 unit tests en cada push/PR a `main`
- **GitHub Pages**: `deploy.yml` publica `src/` via GitHub Actions (no "Deploy from branch")
- **Supabase**: cliente actualiza a `publishableKey` (`sb_publishable_*`), mantiene fallback a `anonKey`
- **E2E tests**: 42 tests Playwright pasando — fix del bloqueo de service workers en el describe Index, fix del test de `localStorage` con Promise dentro de `page.evaluate()`
- **README**: reescrito con instrucciones de deploy, instalación en Android y Mac, uso por paciente y cuidador

## Pasos pendientes tras merge

1. **GitHub Pages**: Settings → Pages → Source → **GitHub Actions** (actualmente en "Deploy from branch")
2. **Supabase Edge Function**: `supabase functions deploy send-push --project-ref vvqpknduifkkfywpiwkn`
3. **VAPID secrets** en Supabase dashboard (Edge Functions → send-push → Secrets)

## Test plan

- [x] 78 unit tests (Jest) pasando — `npm test`
- [x] 42 E2E tests (Playwright) pasando — `npm run test:e2e`
- [x] CI pipeline verde en esta rama
- [x] Ghost submodule `.claude/worktrees/` eliminado — `actions/checkout@v4` funciona
- [ ] Verificar deploy a GitHub Pages tras cambiar Source a "GitHub Actions"
- [ ] Verificar push notifications en Android tras deploy de Edge Function

🤖 Generated with [Claude Code](https://claude.com/claude-code)