### PR TITLE
fix: Infisical method correcto — universal en lugar de universal-auth

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -26,7 +26,20 @@
       "Bash(node -e ' *)",
       "Bash(curl -s https://api.elevenlabs.io/v1/voices -H 'xi-api-key: sk_ac3d3528d0a1bd7ad160199da456255042eb7dbc9fafb8ef')",
       "Bash(node -e \"console.log\\(JSON.stringify\\(require\\('./package.json'\\).scripts, null, 2\\)\\)\")",
-      "Bash(npm run *)"
+      "Bash(npm run *)",
+      "Bash(git commit -m 'docs: README reescrito con deploy, Infisical y instrucciones de usuario *)",
+      "Bash(git ls-tree *)",
+      "Bash(git push *)",
+      "Bash(gh run *)",
+      "Bash(gh api *)",
+      "Bash(gh pr *)",
+      "Bash(infisical secrets *)",
+      "Bash(python3 -c \"import sys,json; d=json.load\\(sys.stdin\\); print\\(json.dumps\\(d,indent=2\\)\\)\")",
+      "Bash(infisical user *)",
+      "Read(//Users/eva/.infisical/**)",
+      "Bash(infisical run *)",
+      "Bash(infisical export *)",
+      "Bash(python3 -c ' *)"
     ]
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Inject secrets from Infisical
         uses: Infisical/secrets-action@v1.0.7
         with:
-          method: universal-auth
+          method: universal
           client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
           client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
           project-slug: "nelson-companion-ea-mt"

--- a/.github/workflows/send-push.yml
+++ b/.github/workflows/send-push.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Inject secrets from Infisical
         uses: Infisical/secrets-action@v1.0.7
         with:
-          method: universal-auth
+          method: universal
           client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
           client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
           project-slug: "nelson-companion-ea-mt"


### PR DESCRIPTION
## Summary

- Corrige el valor del input `method` en `Infisical/secrets-action@v1.0.7`: el valor válido es `"universal"`, no `"universal-auth"`
- El switch interno de la action arroja `"Invalid authentication method"` para cualquier valor que no sea `"universal"` u `"oidc"`
- Aplica a `deploy.yml` y `send-push.yml`

## Test plan

- [ ] Deploy workflow corre sin error en Infisical step
- [ ] `src/env.js` se genera correctamente con los secrets de Infisical
- [ ] GitHub Pages publica sin 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)