### PR TITLE
fix: Infisical env-slug dev — entorno correcto

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
           client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
           client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
           project-slug: "nelson-companion-ea-mt"
-          env-slug: "production"
+          env-slug: "dev"
           secret-path: "/"
           export-type: env
 

--- a/.github/workflows/send-push.yml
+++ b/.github/workflows/send-push.yml
@@ -31,7 +31,7 @@ jobs:
           client-id: ${{ secrets.INFISICAL_CLIENT_ID }}
           client-secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
           project-slug: "nelson-companion-ea-mt"
-          env-slug: "production"
+          env-slug: "dev"
           secret-path: "/"
           export-type: env
 


### PR DESCRIPTION
## Summary

El entorno en Infisical se llama `Development` cuyo slug es `dev`, no `production`. Corrige `env-slug` en `deploy.yml` y `send-push.yml`.

## Test plan

- [ ] Deploy workflow inyecta secrets correctamente desde Infisical
- [ ] `src/env.js` se genera con `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`, etc.
- [ ] GitHub Pages publica sin 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)